### PR TITLE
screen reader, other a11y improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,9 @@
 
   <div class="container">
 
+    <!--aria-live tells screen readers "watch this element for changes". We'll cover it soon!-->
     <main role="main" aria-live="polite" aria-relevant="additions text">
+      
     <!-- html5 boolean hidden allows us to selectively reveal content to all users -->
       <div data-page="start" hidden>
         <h1>Quiz App</h1>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,9 @@
 
   <div class="container">
 
-    <main>
-    <!-- inline styling this instead of CSS because it should never be viewable to anyone except our JS, which uses this content as mini-templates for questions
-    and answers -->
-      <div class="start-page" style="display: none;">
+    <main role="main" aria-live="polite" aria-relevant="additions text">
+    <!-- html5 boolean hidden allows us to selectively reveal content to all users -->
+      <div class="start-page" hidden>
         <h1>Quiz App</h1>
         <p>This app tests your ability to guess the right answer to four questions. The correct answers have been chosen at random.</p>
         <p><em>Good luck friend!</em></p>
@@ -26,17 +25,18 @@
         </form>
       </div>
 
-      <div class="question-page" style="display: none;">
-        <h3><span class="question-count"></span> : <span class="question-text"></span></h3>
+      <div class="question-page" hidden>
         <form name="current-question">
-          <ol type="A" class="choices">
-          </ol>
+          <fieldset>
+            <legend><span class="question-count"></span> : <span class="question-text"></span></legend>
+            <div class="choices"></div>
+          </fieldset>
           <button type="submit">Submit</button>
           <button class="restart-game">Start over</button>
         </form>
       </div>
 
-      <div class="answer-feedback-page" style="display: none;">
+      <div class="answer-feedback-page" hidden>
         <div class="feedback-container">
           <div class="feedback-header"></div>
           <p class="feedback-text"></p>
@@ -44,7 +44,7 @@
         </div>
       </div>
 
-      <div class="final-feedback-page" style="display: none;">
+      <div class="final-feedback-page" hidden>
         <h1>Results</h1>
         <p class="results-text"></p>
         <button class="restart-game">Start over</button>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       </div>
 
       <div data-page="final-feedback" hidden>
-        <h1>Results</h1>
+        <h2>Results</h2>
         <p class="results-text"></p>
         <button class="restart-game">Start over</button>
       </div>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" name="description" content="Exemplary solution for Quiz App challenge in Thinkful's Front End Web Development course">
+  <meta charset="utf-8">
+  <meta name="description" content="Example solution for Quiz App challenge in Thinkful's Front End Web Development course">
 
   <title>Thinkful | Quiz App Solution</title>
 
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css">
-  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
   <!-- <link rel="stylesheet" href="styles/grid.css"> TODO -->
   <link rel="stylesheet" href="styles/main.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
       <div data-page="answer-feedback" hidden>
         <div class="feedback-container">
-          <div class="feedback-header"></div>
+          <h2 class="feedback-header"></h2>
           <p class="feedback-text"></p>
           <button class="see-next"></button>
         </div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
     <main role="main" aria-live="polite" aria-relevant="additions text">
     <!-- html5 boolean hidden allows us to selectively reveal content to all users -->
-      <div class="start-page" hidden>
+      <div data-page="start" hidden>
         <h1>Quiz App</h1>
         <p>This app tests your ability to guess the right answer to four questions. The correct answers have been chosen at random.</p>
         <p><em>Good luck friend!</em></p>
@@ -25,7 +25,7 @@
         </form>
       </div>
 
-      <div class="question-page" hidden>
+      <div data-page="question" hidden>
         <form name="current-question">
           <fieldset>
             <legend><span class="question-count"></span> : <span class="question-text"></span></legend>
@@ -36,7 +36,7 @@
         </form>
       </div>
 
-      <div class="answer-feedback-page" hidden>
+      <div data-page="answer-feedback" hidden>
         <div class="feedback-container">
           <div class="feedback-header"></div>
           <p class="feedback-text"></p>
@@ -44,7 +44,7 @@
         </div>
       </div>
 
-      <div class="final-feedback-page" hidden>
+      <div data-page="final-feedback" hidden>
         <h1>Results</h1>
         <p class="results-text"></p>
         <button class="restart-game">Start over</button>

--- a/index.html
+++ b/index.html
@@ -23,13 +23,13 @@
         <h1>Quiz App</h1>
         <p>This app tests your ability to guess the right answer to four questions. The correct answers have been chosen at random.</p>
         <p><em>Good luck friend!</em></p>
-        <form name="game-start">
+        <form action="#" name="game-start">
           <button type="submit">start</button>
         </form>
       </div>
 
       <div data-page="question" hidden>
-        <form name="current-question">
+        <form action="#" name="current-question">
           <fieldset>
             <legend><span class="question-count"></span> : <span class="question-text"></span></legend>
             <div class="choices"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -179,7 +179,8 @@ function renderFinalFeedbackText(state, element) {
   element.text(text);
 }
 
-// Event handlers
+// Object to map template elements to
+// app routes
 const PAGE_ELEMENTS = {
   'start': $('[data-page=start]'),
   'question': $('[data-page=question]'),
@@ -187,19 +188,25 @@ const PAGE_ELEMENTS = {
   'final-feedback': $('[data-page=final-feedback]')
 };
 
-$("form[name='game-start']").submit(function(event) {
+// Forms, other interactive elements
+const START_FORM = $("form[name='game-start']");
+const QUESTION_FORM = $("form[name='current-question']");
+const NEXT_BTN = $(".see-next");
+const RESTART_BTN = $("button.restart-game");
+
+START_FORM.submit(function(event) {
   event.preventDefault();
   setRoute(state, 'question');
   renderApp(state, PAGE_ELEMENTS);
 });
 
-$(".restart-game").click(function(event){
+RESTART_BTN.click(function(event){
   event.preventDefault();
   resetGame(state);
   renderApp(state, PAGE_ELEMENTS);
 });
 
-$("form[name='current-question']").submit(function(event) {
+QUESTION_FORM.submit(function(event) {
   event.preventDefault();
   const answer = $("input[name='user-answer']:checked").val();
   answer = parseInt(answer, 10);
@@ -207,7 +214,7 @@ $("form[name='current-question']").submit(function(event) {
   renderApp(state, PAGE_ELEMENTS);
 });
 
-$(".see-next").click(function(event) {
+NEXT_BTN.click(function(event) {
   advance(state);
   renderApp(state, PAGE_ELEMENTS);
 });

--- a/js/app.js
+++ b/js/app.js
@@ -90,10 +90,10 @@ function renderApp(state, elements) {
   
 
   if (state.route === 'start') {
-      renderStartPage(state, elements[state.route]);
+    renderStartPage(state, elements[state.route]);
   }
   else if (state.route === 'question') {
-      renderQuestionPage(state, elements[state.route]);
+    renderQuestionPage(state, elements[state.route]);
   }
   else if (state.route === 'answer-feedback') {
     renderAnswerFeedbackPage(state, elements[state.route]);
@@ -141,8 +141,7 @@ function renderQuestionText(state, element) {
 
 function renderChoices(state, element) {
   const currentQuestion = state.questions[state.currentQuestionIndex];
-  const frag = $(document.createDocumentFragment());
-  const choices = currentQuestion.choices.map(function(choice, index) {
+  const choices = currentQuestion.choices.map((choice, index) => {
     return (
         `<label>
           <input type="radio" 
@@ -152,8 +151,7 @@ function renderChoices(state, element) {
         </label>`
     );
   });
-  frag.append(choices);
-  element.html(frag);
+  element.html(choices);
 }
 
 function renderAnswerFeedbackHeader(state, element) {

--- a/js/app.js
+++ b/js/app.js
@@ -154,11 +154,11 @@ function renderChoices(state, element) {
 }
 
 function renderAnswerFeedbackHeader(state, element) {
-  const html = state.lastAnswerCorrect ?
+  const feedback = state.lastAnswerCorrect ?
       "<h2 class='user-was-correct'>correct</h2>" :
       "<h2 class='user-was-incorrect'>Wrooonnnngggg!</h2>";
 
-  element.html(html);
+  element.replaceWith(feedback);
 }
 
 function renderAnswerFeedbackText(state, element) {

--- a/js/app.js
+++ b/js/app.js
@@ -130,7 +130,7 @@ function renderFinalFeedbackPage(state, element) {
 }
 
 function renderQuestionCount(state, element) {
-  const text = (state.currentQuestionIndex + 1) + "/" + state.questions.length;
+  const text = `${(state.currentQuestionIndex + 1)}/${state.questions.length}`;
   element.text(text);
 }
 
@@ -158,7 +158,6 @@ function renderAnswerFeedbackHeader(state, element) {
   const feedback = state.lastAnswerCorrect ?
       "<h2 class='user-was-correct'>correct</h2>" :
       "<h2 class='user-was-incorrect'>Wrooonnnngggg!</h2>";
-
   element.replaceWith(feedback);
 }
 
@@ -175,8 +174,7 @@ function renderNextButtonText(state, element) {
 }
 
 function renderFinalFeedbackText(state, element) {
-  const text = "You got " + state.score + " out of " +
-    state.questions.length + " questions right.";
+  const text = `You got ${state.score} out of ${state.questions.length} questions right.`;
   element.text(text);
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -179,44 +179,48 @@ function renderFinalFeedbackText(state, element) {
   element.text(text);
 }
 
-// Object to map template elements to
-// app routes
-const PAGE_ELEMENTS = {
-  'start': $('[data-page=start]'),
-  'question': $('[data-page=question]'),
-  'answer-feedback': $('[data-page=answer-feedback]'),
-  'final-feedback': $('[data-page=final-feedback]')
-};
+$(function() { 
+  // Forms, other interactive elements
+  const START_FORM = $("form[name='game-start']");
+  const QUESTION_FORM = $("form[name='current-question']");
+  const NEXT_BTN = $(".see-next");
+  const RESTART_BTN = $("button.restart-game");
 
-// Forms, other interactive elements
-const START_FORM = $("form[name='game-start']");
-const QUESTION_FORM = $("form[name='current-question']");
-const NEXT_BTN = $(".see-next");
-const RESTART_BTN = $("button.restart-game");
+  // Object to map template elements to
+  // app routes
+  const PAGE_ELEMENTS = {
+    'start': $('[data-page=start]'),
+    'question': $('[data-page=question]'),
+    'answer-feedback': $('[data-page=answer-feedback]'),
+    'final-feedback': $('[data-page=final-feedback]')
+  };
 
-START_FORM.submit(function(event) {
-  event.preventDefault();
-  setRoute(state, 'question');
-  renderApp(state, PAGE_ELEMENTS);
+  // Attach our event listeners
+  START_FORM.submit(function(event) {
+    event.preventDefault();
+    setRoute(state, 'question');
+    renderApp(state, PAGE_ELEMENTS);
+  });
+
+  RESTART_BTN.click(function(event){
+    event.preventDefault();
+    resetGame(state);
+    renderApp(state, PAGE_ELEMENTS);
+  });
+
+  QUESTION_FORM.submit(function(event) {
+    event.preventDefault();
+    const answer = $("input[name='user-answer']:checked").val();
+    answer = parseInt(answer, 10);
+    answerQuestion(state, answer);
+    renderApp(state, PAGE_ELEMENTS);
+  });
+
+  NEXT_BTN.click(function(event) {
+    advance(state);
+    renderApp(state, PAGE_ELEMENTS);
+  });
+
+  // Finally, render the app.
+  renderApp(state, PAGE_ELEMENTS); 
 });
-
-RESTART_BTN.click(function(event){
-  event.preventDefault();
-  resetGame(state);
-  renderApp(state, PAGE_ELEMENTS);
-});
-
-QUESTION_FORM.submit(function(event) {
-  event.preventDefault();
-  const answer = $("input[name='user-answer']:checked").val();
-  answer = parseInt(answer, 10);
-  answerQuestion(state, answer);
-  renderApp(state, PAGE_ELEMENTS);
-});
-
-NEXT_BTN.click(function(event) {
-  advance(state);
-  renderApp(state, PAGE_ELEMENTS);
-});
-
-$(function() { renderApp(state, PAGE_ELEMENTS); });

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 // State object
-var state = {
+const state = {
   questions: [
     {
       text: "Which number am I thinking of?",
@@ -58,7 +58,7 @@ function resetGame(state) {
 }
 
 function answerQuestion(state, answer) {
-  var currentQuestion = state.questions[state.currentQuestionIndex];
+  const currentQuestion = state.questions[state.currentQuestionIndex];
   state.lastAnswerCorrect = currentQuestion.correctChoiceIndex === answer;
   if (state.lastAnswerCorrect) {
     state.score++;
@@ -127,19 +127,19 @@ function renderFinalFeedbackPage(state, element) {
 }
 
 function renderQuestionCount(state, element) {
-  var text = (state.currentQuestionIndex + 1) + "/" + state.questions.length;
+  const text = (state.currentQuestionIndex + 1) + "/" + state.questions.length;
   element.text(text);
 }
 
 function renderQuestionText(state, element) {
-  var currentQuestion = state.questions[state.currentQuestionIndex];
+  const currentQuestion = state.questions[state.currentQuestionIndex];
   element.text(currentQuestion.text);
 }
 
 function renderChoices(state, element) {
-  var currentQuestion = state.questions[state.currentQuestionIndex];
-  var frag = $(document.createDocumentFragment());
-  var choices = currentQuestion.choices.map(function(choice, index) {
+  const currentQuestion = state.questions[state.currentQuestionIndex];
+  const frag = $(document.createDocumentFragment());
+  const choices = currentQuestion.choices.map(function(choice, index) {
     return (
         `<label>
           <input type="radio" 
@@ -154,7 +154,7 @@ function renderChoices(state, element) {
 }
 
 function renderAnswerFeedbackHeader(state, element) {
-  var html = state.lastAnswerCorrect ?
+  const html = state.lastAnswerCorrect ?
       "<h6 class='user-was-correct'>correct</h6>" :
       "<h1 class='user-was-incorrect'>Wrooonnnngggg!</>";
 
@@ -162,25 +162,25 @@ function renderAnswerFeedbackHeader(state, element) {
 }
 
 function renderAnswerFeedbackText(state, element) {
-  var choices = state.lastAnswerCorrect ? state.praises : state.admonishments;
-  var text = choices[Math.floor(state.feedbackRandom * choices.length)];
+  const choices = state.lastAnswerCorrect ? state.praises : state.admonishments;
+  const text = choices[Math.floor(state.feedbackRandom * choices.length)];
   element.text(text);
 }
 
 function renderNextButtonText(state, element) {
-    var text = state.currentQuestionIndex < state.questions.length - 1 ?
+    const text = state.currentQuestionIndex < state.questions.length - 1 ?
       "Next" : "How did I do?";
   element.text(text);
 }
 
 function renderFinalFeedbackText(state, element) {
-  var text = "You got " + state.score + " out of " +
+  const text = "You got " + state.score + " out of " +
     state.questions.length + " questions right.";
   element.text(text);
 }
 
 // Event handlers
-var PAGE_ELEMENTS = {
+const PAGE_ELEMENTS = {
   'start': $('[data-page=start]'),
   'question': $('[data-page=question]'),
   'answer-feedback': $('[data-page=answer-feedback]'),
@@ -201,7 +201,7 @@ $(".restart-game").click(function(event){
 
 $("form[name='current-question']").submit(function(event) {
   event.preventDefault();
-  var answer = $("input[name='user-answer']:checked").val();
+  const answer = $("input[name='user-answer']:checked").val();
   answer = parseInt(answer, 10);
   answerQuestion(state, answer);
   renderApp(state, PAGE_ELEMENTS);

--- a/js/app.js
+++ b/js/app.js
@@ -182,16 +182,15 @@ $(function() {
   // Forms, other interactive elements
   const START_FORM = $("form[name='game-start']");
   const QUESTION_FORM = $("form[name='current-question']");
-  const NEXT_BTN = $(".see-next");
+  const NEXT_BTN = $("button.see-next");
   const RESTART_BTN = $("button.restart-game");
 
-  // Object to map template elements to
-  // app routes
+  // Object to map template elements to app routes
   const PAGE_ELEMENTS = {
-    'start': $('[data-page=start]'),
-    'question': $('[data-page=question]'),
-    'answer-feedback': $('[data-page=answer-feedback]'),
-    'final-feedback': $('[data-page=final-feedback]')
+    'start': $('div[data-page=start]'),
+    'question': $('div[data-page=question]'),
+    'answer-feedback': $('div[data-page=answer-feedback]'),
+    'final-feedback': $('div[data-page=final-feedback]')
   };
 
   // Attach our event listeners
@@ -200,13 +199,7 @@ $(function() {
     setRoute(state, 'question');
     renderApp(state, PAGE_ELEMENTS);
   });
-
-  RESTART_BTN.on('click', function(event){
-    event.preventDefault();
-    resetGame(state);
-    renderApp(state, PAGE_ELEMENTS);
-  });
-
+  
   QUESTION_FORM.on('submit', function(event) {
     event.preventDefault();
     let answer = $("input[name='user-answer']:checked").val();
@@ -217,6 +210,12 @@ $(function() {
 
   NEXT_BTN.on('click', function(event) {
     advance(state);
+    renderApp(state, PAGE_ELEMENTS);
+  });
+  
+  RESTART_BTN.on('click', function(event){
+    event.preventDefault();
+    resetGame(state);
     renderApp(state, PAGE_ELEMENTS);
   });
 

--- a/js/app.js
+++ b/js/app.js
@@ -195,19 +195,19 @@ $(function() {
   };
 
   // Attach our event listeners
-  START_FORM.submit(function(event) {
+  START_FORM.on('submit', function(event) {
     event.preventDefault();
     setRoute(state, 'question');
     renderApp(state, PAGE_ELEMENTS);
   });
 
-  RESTART_BTN.click(function(event){
+  RESTART_BTN.on('click', function(event){
     event.preventDefault();
     resetGame(state);
     renderApp(state, PAGE_ELEMENTS);
   });
 
-  QUESTION_FORM.submit(function(event) {
+  QUESTION_FORM.on('submit', function(event) {
     event.preventDefault();
     let answer = $("input[name='user-answer']:checked").val();
     answer = parseInt(answer, 10);
@@ -215,7 +215,7 @@ $(function() {
     renderApp(state, PAGE_ELEMENTS);
   });
 
-  NEXT_BTN.click(function(event) {
+  NEXT_BTN.on('click', function(event) {
     advance(state);
     renderApp(state, PAGE_ELEMENTS);
   });

--- a/js/app.js
+++ b/js/app.js
@@ -85,9 +85,9 @@ function advance(state) {
 function renderApp(state, elements) {
   // default to hiding all routes, then show the current route
   Object.keys(elements).forEach(function(route) {
-    elements[route].hide();
+    elements[route].attr('hidden', 'hidden');
   });
-  elements[state.route].show();
+  elements[state.route].removeAttr('hidden');
 
   if (state.route === 'start') {
       renderStartPage(state, elements[state.route]);
@@ -138,16 +138,19 @@ function renderQuestionText(state, element) {
 
 function renderChoices(state, element) {
   var currentQuestion = state.questions[state.currentQuestionIndex];
+  var frag = $(document.createDocumentFragment());
   var choices = currentQuestion.choices.map(function(choice, index) {
     return (
-      '<li>' +
-        '<label>' +
-          '<input type="radio" name="user-answer" value="' + index + '" id="choice-'+ index +'"required>' + choice +
-        '</label>' +
-      '</li>'
+        `<label>
+          <input type="radio" 
+            name="user-answer" 
+            value="${index}" 
+            id="choice-${index}" required> ${choice}
+        </label>`
     );
   });
-  element.html(choices);
+  frag.append(choices);
+  element.html(frag);
 }
 
 function renderAnswerFeedbackHeader(state, element) {

--- a/js/app.js
+++ b/js/app.js
@@ -87,7 +87,7 @@ function renderApp(state, elements) {
   Object.keys(elements).forEach(function(route) {
     elements[route].attr('hidden', 'hidden');
   });
-  elements[state.route].removeAttr('hidden');
+  
 
   if (state.route === 'start') {
       renderStartPage(state, elements[state.route]);
@@ -101,6 +101,9 @@ function renderApp(state, elements) {
   else if (state.route === 'final-feedback') {
     renderFinalFeedbackPage(state, elements[state.route]);
   }
+  
+  //show current route after it has been invisibly rendered
+  elements[state.route].removeAttr('hidden');
 }
 
 // at the moment, `renderStartPage` doesn't do anything, because

--- a/js/app.js
+++ b/js/app.js
@@ -155,8 +155,8 @@ function renderChoices(state, element) {
 
 function renderAnswerFeedbackHeader(state, element) {
   const html = state.lastAnswerCorrect ?
-      "<h6 class='user-was-correct'>correct</h6>" :
-      "<h1 class='user-was-incorrect'>Wrooonnnngggg!</>";
+      "<h2 class='user-was-correct'>correct</h2>" :
+      "<h2 class='user-was-incorrect'>Wrooonnnngggg!</h2>";
 
   element.html(html);
 }
@@ -210,7 +210,7 @@ $(function() {
 
   QUESTION_FORM.submit(function(event) {
     event.preventDefault();
-    const answer = $("input[name='user-answer']:checked").val();
+    let answer = $("input[name='user-answer']:checked").val();
     answer = parseInt(answer, 10);
     answerQuestion(state, answer);
     renderApp(state, PAGE_ELEMENTS);

--- a/js/app.js
+++ b/js/app.js
@@ -143,7 +143,7 @@ function renderChoices(state, element) {
   const currentQuestion = state.questions[state.currentQuestionIndex];
   const choices = currentQuestion.choices.map((choice, index) => {
     return (
-        `<label>
+        `<label for="choice-${index}">
           <input type="radio" 
             name="user-answer" 
             value="${index}" 

--- a/js/app.js
+++ b/js/app.js
@@ -181,10 +181,10 @@ function renderFinalFeedbackText(state, element) {
 
 // Event handlers
 var PAGE_ELEMENTS = {
-  'start': $('.start-page'),
-  'question': $('.question-page'),
-  'answer-feedback': $('.answer-feedback-page'),
-  'final-feedback': $('.final-feedback-page')
+  'start': $('[data-page=start]'),
+  'question': $('[data-page=question]'),
+  'answer-feedback': $('[data-page=answer-feedback]'),
+  'final-feedback': $('[data-page=final-feedback]')
 };
 
 $("form[name='game-start']").submit(function(event) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -13,6 +13,12 @@ main {
 	line-height: 1.5;
 }
 
+fieldset {
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
 label {
 	display: block;
     font-size: 1rem;
@@ -23,7 +29,6 @@ input[type=radio] {
     vertical-align: middle;
     height: 1.5rem;
     bottom: 2px;
-    *bottom: 0;
     margin-right: 7px;
 }
 
@@ -34,6 +39,15 @@ p {
 .container {
 	padding: 0 60px;
 	padding-top: 90px;
+}
+
+legend {
+	font-size: 20px;
+	font-weight: bold;
+}
+
+.choices {
+	padding: 10px;
 }
 
 .user-was-correct{

--- a/styles/main.css
+++ b/styles/main.css
@@ -3,6 +3,9 @@
 	font-family: 'Roboto', sans-serif;
 }
 
+html {
+	font-size: 16px;
+}
 
 main {
 	max-width: 960px;
@@ -33,6 +36,10 @@ p {
 	padding-top: 90px;
 }
 
+.user-was-correct{
+	font-size: 12px;
+}
+
 .user-was-correct::before {
 	content: "Shhhh!!!!! (";
 }
@@ -43,5 +50,6 @@ p {
 
 .user-was-incorrect {
 	font-size: 50px;
+	margin: 10px 0;
 	color: red;
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -7,11 +7,12 @@
 main {
 	max-width: 960px;
 	margin: 0 auto;
+	line-height: 1.5;
 }
 
 label {
+	display: block;
     font-size: 1rem;
-    line-height: 1.5;
 }
 
 input[type=radio] {


### PR DESCRIPTION
In this PR:
- `main` gets `aria-live=polite` so that DOM changes get reported to screen readers (and a note that we will explain aria-live later)
- HTML `data-*` is used to  target separate templates, instead of classes.
- Templates are hidden with boolean `hidden` so that their appearance in the DOM registers as a change with ARIA
- Templates get better HTML in minor ways - larger font sizes, better colors for WCAG, explicit `for` attributes.
- `var` declarations have been replaced with `const` and `let`
- listeners are set with `.on()`, consistent with most of our other code.
